### PR TITLE
Add in -w "workspace" flag to docker command, so users do not have to cd after starting docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Run the followings in your terminal:
 
 ```
 $ cd [your working directory]
-$ docker run -it -v $(pwd):/usr/workspace joyzoursky/python-chromedriver:[version] sh
-/ # cd /usr/workspace
+$ docker run -it -w /usr/workspace -v $(pwd):/usr/workspace joyzoursky/python-chromedriver:[version] sh
 ```
 
 For the following ubuntu based images:


### PR DESCRIPTION
Add in `-w` "workspace" flag to docker command, so users do not have to cd after starting docker.

@joyzoursky BTW This is a fantastic project!