### PR TITLE
Resolve page crash error due to /dev/shm size

### DIFF
--- a/test_script.py
+++ b/test_script.py
@@ -15,6 +15,7 @@ class TestTemplate(unittest.TestCase):
         chrome_options.add_argument('--no-sandbox')
         chrome_options.add_argument('--headless')
         chrome_options.add_argument('--disable-gpu')
+        chrome_options.add_argument('--disable-dev-shm-usage')
         chrome_options.add_argument("--window-size=1920,1080")
         self.driver = webdriver.Chrome(options=chrome_options)
         self.driver.implicitly_wait(10)


### PR DESCRIPTION
An error occurs occasionally when running the test script:
`selenium.common.exceptions.WebDriverException: Message: unknown error: session deleted because of page crash`

Ref solution: https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot

Updated `test_script.py` by adding the following chrome option:
`chrome_options.add_argument('--disable-dev-shm-usage')`

ref issue #3 